### PR TITLE
feat: ignore diacritics in location search box

### DIFF
--- a/src/lib/components/LocationSearchBox.svelte
+++ b/src/lib/components/LocationSearchBox.svelte
@@ -14,10 +14,27 @@
 	let highlightedIndex = $state(-1)
 	let el = $state<HTMLInputElement>()
 
+	function removeDiacritics(str: string) {
+		return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+	}
+
 	const locations = $derived(getAllLocations(appState.selectedPack?.locations ?? []))
-	const searchResults = $derived(
-		locations.filter((loc) => loc.name?.toLowerCase().includes(searchQuery.toLowerCase()))
-	)
+
+	const locationSearchFilter = $derived((loc: Location) => {
+		const regex = new RegExp(removeDiacritics(searchQuery), 'gi')
+
+		// TODO: Path search is too slow atm, need to optimize paths first (add them at import/creation step, most likely)
+		// const path = findLocation(appState.selectedPack?.locations ?? [], loc)[1]
+		// const matchesPath = regex.test(removeDiacritics(path))
+		const matchesName = regex.test(removeDiacritics(loc.name ?? ''))
+		const matchesSection = loc.sections?.some((section) =>
+			regex.test(removeDiacritics(section.name ?? ''))
+		)
+
+		return matchesName || matchesSection
+	})
+
+	const searchResults = $derived(locations.filter(locationSearchFilter))
 
 	$effect(() => {
 		if (!el) {

--- a/src/lib/components/LocationSearchBox.svelte.spec.ts
+++ b/src/lib/components/LocationSearchBox.svelte.spec.ts
@@ -138,4 +138,26 @@ describe('LocationSearchBox', () => {
 
 		await expect.element(getByRole('combobox')).toHaveFocus()
 	})
+
+	it('should match results case-insensitively and ignoring diacritics', async () => {
+		const pack = appState.selectedPack!
+		pack.locations.push(makeLocation({ name: 'Café' }))
+
+		const { getByRole, getByText } = render(LocationSearchBox, { onSelect: vi.fn() })
+		await getByRole('combobox').fill('E')
+
+		await expect.element(getByText('Café')).toBeVisible()
+	})
+
+	it('should match section names', async () => {
+		const pack = appState.selectedPack!
+		pack.locations.push(
+			makeLocation({ name: 'Location with section', sections: [{ name: 'Secret Area' }] })
+		)
+
+		const { getByRole, getByText } = render(LocationSearchBox, { onSelect: vi.fn() })
+		await getByRole('combobox').fill('Secret')
+
+		await expect.element(getByText('Location with section')).toBeVisible()
+	})
 })


### PR DESCRIPTION
Also match location sections (part of #74).

Close #73